### PR TITLE
Omit Nones from patches for new nested dicts

### DIFF
--- a/kmock/_internal/k8s_dicts.py
+++ b/kmock/_internal/k8s_dicts.py
@@ -40,6 +40,8 @@ def patch_dict(value: Mapping[str, Any], patch: Mapping[str, Any], /, **kwargs: 
                 result[key] = value[key]
             case _, _ if patch[key] is None:  # deleted keys
                 pass
+            case _, collections.abc.Mapping() if key not in value:  # new appended keys
+                result[key] = patch_dict({}, patch[key])
             case _, _ if key not in value:  # new appended keys
                 result[key] = patch[key]
             case collections.abc.Mapping(), collections.abc.Mapping():

--- a/tests/dsl/objects/test_object_patching.py
+++ b/tests/dsl/objects/test_object_patching.py
@@ -31,6 +31,11 @@ def test_patch_key_removal_via_kwargs():
     assert d == {}
 
 
+def test_patch_nested_nulls_removal():
+    d = patch_dict({}, {'spec': {'key': None, 'other': 'unaffected'}})
+    assert d == {'spec': {'other': 'unaffected'}}
+
+
 def test_patch_recursive_dicts():
     d = {'spec': {'key': 'old', 'other': 'unaffected'}}
     p = {'spec': {'key': 'new'}}


### PR DESCRIPTION
Previously, it was setting the whole patch dict as the new value, even if that patch included Nones internally. By the semantics of K8s, None/null means deletion, so it should not be stored.
