### PR TITLE
Fix the too fast tests in PyPy

### DIFF
--- a/tests/dsl/responses/test_effects.py
+++ b/tests/dsl/responses/test_effects.py
@@ -206,9 +206,12 @@ async def test_async_condition_notifying(kmock: RawHandler) -> None:
 
     task = asyncio.create_task(wait())
     await kmock.get('/')
-    assert counter == 1
+    async with condition:
+        assert counter == 1
+
     await kmock.post('/')
-    assert counter == 2
+    async with condition:
+        assert counter == 2
 
     task.cancel()
     try:
@@ -234,12 +237,18 @@ async def test_sync_condition_notifying(kmock: RawHandler) -> None:
 
     thread = threading.Thread(target=wait)
     thread.start()
-    ready.wait()
 
+    ready.wait()
+    ready.clear()
     await kmock.get('/')
-    assert counter == 1
+    with condition:
+        assert counter == 1
+
+    ready.wait()
+    ready.clear()
     await kmock.post('/')
-    assert counter == 2
+    with condition:
+        assert counter == 2
 
     exited = True
     with condition:


### PR DESCRIPTION
At was happening that way because PyPy is too fast:

- The "ready" state was properly entered.
- The condition was awaited (lock released).
- The request was made, the condition was locked & notified.
- The request was finished and the counter==1 checked.
- The condition was locked after way and the counter was incremented by +1.

The expectation was that the last two steps are swapped: increment first, the check later.

This lead to flappy tests in PyPy 3.11, which were failing sometimes, but not always.

Now, the counter check is also put under the condition's lock, so it is properly synchronised, and the counter is secured by the same condition in all places where it is used.
