### PR TITLE
Fix the race condition in tests of side effects

### DIFF
--- a/tests/dsl/responses/test_effects.py
+++ b/tests/dsl/responses/test_effects.py
@@ -4,6 +4,7 @@ import io
 import queue
 import sys
 import threading
+import time
 from typing import Any, AsyncIterator, Iterator
 
 import pytest
@@ -206,10 +207,12 @@ async def test_async_condition_notifying(kmock: RawHandler) -> None:
 
     task = asyncio.create_task(wait())
     await kmock.get('/')
+    await asyncio.sleep(0.1)  # give the task priority in acquiring the lock before us
     async with condition:
         assert counter == 1
 
     await kmock.post('/')
+    await asyncio.sleep(0.1)  # give the task priority in acquiring the lock before us
     async with condition:
         assert counter == 2
 
@@ -241,12 +244,14 @@ async def test_sync_condition_notifying(kmock: RawHandler) -> None:
     ready.wait()
     ready.clear()
     await kmock.get('/')
+    time.sleep(0.1)  # give the thread priority in acquiring the lock before us
     with condition:
         assert counter == 1
 
     ready.wait()
     ready.clear()
     await kmock.post('/')
+    time.sleep(0.1)  # give the thread priority in acquiring the lock before us
     with condition:
         assert counter == 2
 


### PR DESCRIPTION
The issue was causing the test flakiness in one particular test, usually in Python 3.10.

**How it happened:** Somehow, we were acquiring the lock sooner than the thread (when exiting from `wait()`). For this, the whole response flow after the condition triggering should be extremely fast, but this is not impossible.

**Solution:** An artificial delay in the test body ensures (or increases the probability) that the thread acquires the lock sooner than the assertions. Another way would be to simulate a slow response by sleeping server-side, but this is not different from sleepin client-side.